### PR TITLE
✨ 관리자페이지 챗봇 응답 전체조회 기능 추가

### DIFF
--- a/src/app/admin/chatbot/ChatbotAdminClient.tsx
+++ b/src/app/admin/chatbot/ChatbotAdminClient.tsx
@@ -1,5 +1,84 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { CHATBOT_API } from '@/constants/chatbot';
+import type { ChatbotPrompt } from '@/types/chatbot';
+
 export default function ChatbotAdminClient() {
-  return <div></div>;
+  const [prompts, setPrompts] = useState<ChatbotPrompt[]>([]);
+
+  const fetchPrompts = async () => {
+    try {
+      const token = process.env.NEXT_PUBLIC_ADMIN_TOKEN!;
+
+      const res = await fetch(CHATBOT_API.BASE, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      const data = await res.json();
+
+      if (Array.isArray(data)) {
+        setPrompts(data);
+      }
+    } catch (error) {
+      console.error('프롬프트 조회 실패:', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchPrompts();
+  }, []);
+
+  return (
+    <div className='p-36 pt-20'>
+      <div className='mb-6 flex items-center justify-between'>
+        <h2 className='text-xl font-bold'>전체 응답 목록</h2>
+        <Button className='bg-main-light hover:bg-main-dark text-white'>+ 추가하기</Button>
+      </div>
+
+      <div className='overflow-auto rounded-md border border-gray-200 shadow-sm'>
+        <table className='min-w-full text-left text-sm'>
+          <thead className='border-b bg-gray-50 font-semibold text-gray-700'>
+            <tr>
+              <th className='px-4 py-3'>STEP</th>
+              <th className='px-4 py-3'>선택 경로</th>
+              <th className='px-4 py-3'>응답</th>
+              <th className='px-4 py-3'>옵션</th>
+              <th className='px-4 py-3'>종료</th>
+              <th className='px-4 py-3 text-right'>관리</th>
+            </tr>
+          </thead>
+          <tbody>
+            {prompts.map((item) => (
+              <tr key={item.id} className='border-t'>
+                <td className='px-4 py-2'>{item.step}</td>
+                <td className='px-4 py-2'>{item.selection_path}</td>
+                <td className='px-4 py-2 text-gray-700'>{item.answer}</td>
+                <td className='px-4 py-2 text-gray-500'>{item.options ?? '없음'}</td>
+                <td className='px-4 py-2'>{item.is_terminate ? '✅' : ''}</td>
+                <td className='px-4 py-2 text-right'>
+                  <Button size='sm' variant='outline' className='mr-2'>
+                    수정
+                  </Button>
+                  <Button size='sm' variant='destructive'>
+                    삭제
+                  </Button>
+                </td>
+              </tr>
+            ))}
+
+            {prompts.length === 0 && (
+              <tr>
+                <td colSpan={6} className='px-4 py-6 text-center text-gray-400'>
+                  프롬프트가 없습니다.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
 }

--- a/src/app/admin/chatbot/page.tsx
+++ b/src/app/admin/chatbot/page.tsx
@@ -3,7 +3,6 @@ import ChatbotAdminClient from './ChatbotAdminClient';
 export default async function ChatbotAdminPage() {
   return (
     <div>
-      <h1>챗봇 관리</h1>
       <ChatbotAdminClient />
     </div>
   );

--- a/src/constants/chatbot.ts
+++ b/src/constants/chatbot.ts
@@ -1,4 +1,4 @@
 export const CHATBOT_API = {
-  BASE: `${process.env.NEXT_PUBLIC_API_URL}/api/admin/chatbot`,
-  DETAIL: (id: number) => `${process.env.NEXT_PUBLIC_API_URL}/api/admin/chatbot/${id}`,
+  BASE: `http://localhost:8000/api/admin/chatbot`,
+  DETAIL: (id: number) => `http://localhost:8000/api/admin/chatbot/${id}`,
 };

--- a/src/types/chatbot.ts
+++ b/src/types/chatbot.ts
@@ -1,7 +1,13 @@
-export interface ChatbotResponse {
+export interface ChatbotBase {
   step: number;
   selection_path: string;
   answer: string;
   options: string | null;
   is_terminate: boolean;
 }
+
+export interface ChatbotPrompt extends ChatbotBase {
+  id: number;
+}
+
+export type ChatbotResponse = ChatbotBase;


### PR DESCRIPTION
관리자페이지 챗봇 응답 전체조회 기능 추가

## #️⃣ 연관된 이슈

> ex) #48 

## 📝 작업 내용

> 관리자 페이지에서 챗봇관리 페이지 클릭 시 응답을 전체 조회할 수 있도록 표를 구성, api 연동해 DB에 저장된 응답을 불러왔습니다.

### 스크린샷 (선택)
![스크린샷 2025-04-21 오후 2 15 34](https://github.com/user-attachments/assets/2cc4a007-172a-4187-8e16-a3be37ffdac3)

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
