### PR TITLE
✅ 서버 내 url 테스트

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const axiosInstance = axios.create({
-  baseURL: 'http://localhost:8000',
+  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
   withCredentials: true,
   // adapter: 'fetch',
 });


### PR DESCRIPTION
localhost:8000 실패

## #️⃣ 연관된 이슈

> ex) #83 서버 내 URL 테스트

## 📝 작업 내용

> 도커 컨테이너들로 구성한 네트워크 내에서 백엔드 찾아가기
> 옵션 1. http://localhost:8000 (아마 실패)
> 옵션 2. http://backend-fast:8000 (아마 성공)
> 네트워크 이름으로 찾아가야 하는듯

### 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

> 
