### PR TITLE
 챗봇 돌아가기,이동하기,뒤로가기 기능 추가

### DIFF
--- a/src/app/(chatbot)/chatbot-test/page.tsx
+++ b/src/app/(chatbot)/chatbot-test/page.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import ChatbotButton from '@/components/chatbot/ChatbotButton';
 
 export default function ChatbotPlayground() {

--- a/src/components/admin/chatbot/ChatbotAdminClient.tsx
+++ b/src/components/admin/chatbot/ChatbotAdminClient.tsx
@@ -15,7 +15,7 @@ const fetcher = async (url: string): Promise<ChatbotPrompt[]> => {
     headers: {
       Authorization: `Bearer ${token}`,
     },
-  });
+  });//GET 요청 + 토큰 인증 + JSON 파싱
 
   if (!res.ok) throw new Error('데이터 불러오기 실패');
   const data = await res.json();

--- a/src/components/admin/chatbot/ChatbotModal.tsx
+++ b/src/components/admin/chatbot/ChatbotModal.tsx
@@ -24,6 +24,7 @@ export default function ChatbotModal({ open, onClose, onSuccess, editTarget }: P
   const [options, setOptions] = useState('');
   const [isTerminate, setIsTerminate] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [redirectUrl, setRedirectUrl] = useState('');
 
   // 모달 열릴 때 초기값
   useEffect(() => {
@@ -34,6 +35,7 @@ export default function ChatbotModal({ open, onClose, onSuccess, editTarget }: P
         setAnswer(editTarget.answer);
         setOptions(editTarget.options || '');
         setIsTerminate(editTarget.is_terminate);
+        setRedirectUrl(editTarget.url || '');
       } else {
         resetForm();
       }
@@ -46,6 +48,7 @@ export default function ChatbotModal({ open, onClose, onSuccess, editTarget }: P
     setAnswer('');
     setOptions('');
     setIsTerminate(false);
+    setRedirectUrl('');
   };
 
   const handleSubmit = async () => {
@@ -66,8 +69,8 @@ export default function ChatbotModal({ open, onClose, onSuccess, editTarget }: P
           selection_path: selectionPath.trim(),
           answer,
           options: options.trim(),
-          // .replace(/^"|"$/g, ''),
           is_terminate: isTerminate,
+          url: redirectUrl.trim(),
         }),
       });
 
@@ -115,6 +118,11 @@ export default function ChatbotModal({ open, onClose, onSuccess, editTarget }: P
             <Checkbox checked={isTerminate} onCheckedChange={(v) => setIsTerminate(!!v)} />
             종료 응답 여부
           </label>
+          <Input
+            placeholder='이동할 URL (예: /free-board)'
+            value={redirectUrl}
+            onChange={(e) => setRedirectUrl(e.target.value)}
+          />
           <div className='mt-4 text-right'>
             <Button onClick={handleSubmit} disabled={loading}>
               {loading ? '저장 중...' : '저장'}

--- a/src/components/admin/chatbot/columns.tsx
+++ b/src/components/admin/chatbot/columns.tsx
@@ -32,8 +32,11 @@ export const getColumns = ({ onEdit, onDelete }: ActionsProps): ColumnDef<Chatbo
     cell: ({ row }) => (row.original.is_terminate ? '✅' : ''),
   },
   {
+    accessorKey: 'url',
+    header: 'URL',
+  },
+  {
     id: 'actions',
-    header: '관리',
     cell: ({ row }) => (
       <div className='flex justify-end gap-2'>
         <Button size='sm' variant='outline' onClick={() => onEdit(row.original)}>

--- a/src/components/chatbot/ChatbotPopup.tsx
+++ b/src/components/chatbot/ChatbotPopup.tsx
@@ -10,6 +10,7 @@ export default function ChatbotPopup() {
 
   const [chatData, setChatData] = useState<ChatbotResponse | null>(null);
   const [selectionPath, setSelectionPath] = useState<string[]>([]);
+  const [resetFlag, setResetFlag] = useState(false); // 돌아가기 눌렀을 때 초기화
 
   useEffect(() => {
     const ws = new WebSocket('ws://localhost:8000/api/ws/');
@@ -21,6 +22,7 @@ export default function ChatbotPopup() {
 
     ws.onmessage = (event) => {
       try {
+        console.log('WebSocket 응답 도착:', event.data);
         const data: ChatbotResponse = JSON.parse(event.data);
         setChatData(data);
       } catch (err) {
@@ -39,20 +41,29 @@ export default function ChatbotPopup() {
     return () => {
       ws.close();
     };
-  }, []);
+  }, [resetFlag]);
 
+  //옵션 선택 후 처리
   const handleSelect = (option: string) => {
     const trimmed = option.trim();
     const newPath = [...selectionPath, option];
-
     setSelectionPath(newPath);
     socketRef.current?.send(trimmed);
+    console.log(trimmed);
   };
 
+  //뒤로가기
+  const handleBack = () => {
+    if (selectionPath.length === 0) return;
+    setSelectionPath((prev) => prev.slice(0, -1)); // 상태는 유지
+    socketRef.current?.send('reverse'); // 서버에 뒤로가기 요청 전송
+  };
+
+  //전체 리셋
   const handleReset = () => {
     setSelectionPath([]);
     setChatData(null);
-    socketRef.current?.send('');
+    setResetFlag((prev) => !prev); //useEffect 재실행
   };
 
   return (
@@ -60,9 +71,15 @@ export default function ChatbotPopup() {
       side='bottom'
       className='!right-26 bottom-[170px] !left-auto w-full max-w-[360px] rounded-2xl border bg-white p-6 shadow-lg'
     >
-      <SheetHeader>
-        <SheetTitle className='sr-only'>챗봇</SheetTitle>
-      </SheetHeader>
+      {/* 뒤로가기 버튼 */}
+      <div className='flex items-center justify-between'>
+        <button onClick={handleBack} disabled={selectionPath.length === 0}>
+          <span className='text-xl text-gray-500'>{'←'}</span>
+        </button>
+        <SheetHeader>
+          <SheetTitle className='sr-only'>챗봇</SheetTitle>
+        </SheetHeader>
+      </div>
 
       {chatData && chatData.answer && (
         <div className='mb-4'>
@@ -96,9 +113,17 @@ export default function ChatbotPopup() {
           <Button onClick={handleReset} variant='outline' className='rounded-md px-3 py-1 text-sm'>
             돌아가기
           </Button>
-          <Button className='bg-main-light rounded-md px-3 py-1 text-sm text-white hover:bg-green-600'>
-            이동하기
-          </Button>
+
+          {chatData.url && (
+            <Button
+              onClick={() => {
+                window.location.href = chatData.url!; // undefined 아님
+              }}
+              className='bg-main-light rounded-md px-3 py-1 text-sm text-white hover:bg-green-600'
+            >
+              이동하기
+            </Button>
+          )}
         </div>
       )}
     </SheetContent>

--- a/src/types/chatbot.ts
+++ b/src/types/chatbot.ts
@@ -4,6 +4,7 @@ export interface ChatbotBase {
   answer: string;
   options: string | null;
   is_terminate: boolean;
+  url?: string;
 }
 
 export interface ChatbotPrompt extends ChatbotBase {


### PR DESCRIPTION
챗봇 돌아가기,이동하기,뒤로가기 기능 추가

## #️⃣ 연관된 이슈

> ex) #63 

## 📝 작업 내용

>  챗봇 돌아가기,이동하기,뒤로가기 기능 추가했습니다.
돌아가기 버튼은 클릭시 챗봇 처음 화면으로 돌아갑니다.
이동하기 추가하면서 관리자페이지에서 응답에 url 넣을 수 있는 칸도 추가했고, 이동할 url이 없을 경우, 이동하기 버튼이 보이지 않게 처리했습니다. 
뒤로가기 버튼은 상단 좌측에 화살표로 표시해, 클릭 시 한 단계 전으로 돌아갑니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
