### PR TITLE
💄 채팅창 말풍선 줄바꿈 적용

### DIFF
--- a/src/components/chatbot/ChatbotPopup.tsx
+++ b/src/components/chatbot/ChatbotPopup.tsx
@@ -103,13 +103,13 @@ export default function ChatbotPopup() {
       <div className='flex flex-col gap-4'>
         {chatLog.map((chat, idx) => (
           <div key={idx} className={chat.sender === 'user' ? 'text-right' : 'text-left'}>
-            <div
+            <p
               className={`inline-block rounded-lg px-4 py-2 whitespace-pre-line ${
                 chat.sender === 'user' ? 'bg-green-200 text-gray-700' : 'bg-gray-200 text-gray-700'
               }`}
             >
-              {chat.message}
-            </div>
+              {chat.message.replace(/\\n/g, '\n')}
+            </p>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #116 

## 📝 작업 내용

> 채팅창 말풍선 줄바꿈 pre태그는 글자간격 너무 넓어서 div 태그로 수정했는데, 반영이 안되어서 \n으로 변환해주는 코드로 수정했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
