### PR TITLE
관리자용 회원관리 페이지 구현

### DIFF
--- a/src/app/admin/resume/[id]/page.tsx
+++ b/src/app/admin/resume/[id]/page.tsx
@@ -1,18 +1,26 @@
 import AdminLayout from '@/components/layout/AdminLayout';
+import DeleteResumeButton from '@/components/resume/DeleteResumeButton';
 import Resume from '@/components/resume/Resume';
 
-// interface Props {
-//   params: { id: string };
-// }
+interface Props {
+  params: { id: string };
+}
 
-export default async function AdminResumeDetailPage() {
-  // const id = params.id;
+export default async function AdminResumeDetailPage({ params }: Props) {
+  const resumeId = params.id;
 
   return (
     <AdminLayout>
       <section className='flex flex-col gap-4 rounded-md bg-white px-8 py-10'>
-        <h2 className='border-b pb-4 text-2xl font-bold'>이력서 상세</h2>
-        <Resume /> {/* 현재는 내부 mock 사용 */}
+        {/* 버튼을 감싸서 너비 제어 */}
+        <div className='flex items-center justify-between border-b pb-4'>
+          <h2 className='text-2xl font-bold'>이력서 상세</h2>
+          <div className='flex justify-end'>
+            <DeleteResumeButton id={resumeId} />
+          </div>
+        </div>
+
+        <Resume />
       </section>
     </AdminLayout>
   );

--- a/src/app/admin/resume/[id]/page.tsx
+++ b/src/app/admin/resume/[id]/page.tsx
@@ -1,0 +1,19 @@
+import AdminLayout from '@/components/layout/AdminLayout';
+import Resume from '@/components/resume/Resume';
+
+// interface Props {
+//   params: { id: string };
+// }
+
+export default async function AdminResumeDetailPage() {
+  // const id = params.id;
+
+  return (
+    <AdminLayout>
+      <section className='flex flex-col gap-4 rounded-md bg-white px-8 py-10'>
+        <h2 className='border-b pb-4 text-2xl font-bold'>이력서 상세</h2>
+        <Resume /> {/* 현재는 내부 mock 사용 */}
+      </section>
+    </AdminLayout>
+  );
+}

--- a/src/app/admin/resume/[id]/page.tsx
+++ b/src/app/admin/resume/[id]/page.tsx
@@ -2,17 +2,13 @@ import AdminLayout from '@/components/layout/AdminLayout';
 import DeleteResumeButton from '@/components/resume/DeleteResumeButton';
 import Resume from '@/components/resume/Resume';
 
-interface Props {
-  params: { id: string };
-}
-
-export default async function AdminResumeDetailPage({ params }: Props) {
+// 수정: Props 인터페이스 제거하고 params에 직접 타입 지정
+export default async function AdminResumeDetailPage({ params }: { params: { id: string } }) {
   const resumeId = params.id;
 
   return (
     <AdminLayout>
       <section className='flex flex-col gap-4 rounded-md bg-white px-8 py-10'>
-        {/* 버튼을 감싸서 너비 제어 */}
         <div className='flex items-center justify-between border-b pb-4'>
           <h2 className='text-2xl font-bold'>이력서 상세</h2>
           <div className='flex justify-end'>

--- a/src/app/admin/resume/[id]/page.tsx
+++ b/src/app/admin/resume/[id]/page.tsx
@@ -1,10 +1,13 @@
+'use client';
+
+import { useParams } from 'next/navigation';
 import AdminLayout from '@/components/layout/AdminLayout';
 import DeleteResumeButton from '@/components/resume/DeleteResumeButton';
 import Resume from '@/components/resume/Resume';
 
-// 수정: Props 인터페이스 제거하고 params에 직접 타입 지정
-export default async function AdminResumeDetailPage({ params }: { params: { id: string } }) {
-  const resumeId = params.id;
+export default function AdminResumeDetailPage() {
+  const params = useParams();
+  const resumeId = params.id as string;
 
   return (
     <AdminLayout>
@@ -21,3 +24,4 @@ export default async function AdminResumeDetailPage({ params }: { params: { id: 
     </AdminLayout>
   );
 }
+//나중에 API 연동, 그때 async function으로 다시 서버 컴포넌트화 가능

--- a/src/app/admin/user/[id]/page.tsx
+++ b/src/app/admin/user/[id]/page.tsx
@@ -1,3 +1,4 @@
+import AdminLayout from '@/components/layout/AdminLayout';
 import SeekerProfile from '@/components/profile/SeekerProfile';
 
 interface Props {
@@ -8,12 +9,13 @@ export default async function AdminUserProfilePage(props: Props) {
   const { id } = await props.params; // 'params'를 await해서 'id' 추출
 
   return (
-    <section className='flex flex-col gap-4 rounded-md bg-white px-8 py-10'>
-      <h2 className='border-b pb-2 text-2xl font-bold'>회원 프로필</h2>
-      <SeekerProfile id={Promise.resolve(id)} /> {/* 'id'를 Promise로 전달 */}
-    </section>
+    <AdminLayout>
+      <section className='flex flex-col gap-4 rounded-md bg-white px-8 py-10'>
+        <h2 className='border-b pb-2 text-2xl font-bold'>회원 프로필</h2>
+        <SeekerProfile id={Promise.resolve(id)} /> {/* 'id'를 Promise로 전달 */}
+      </section>
+    </AdminLayout>
   );
 }
 
-// SeekerProfile 컴포넌트는 id를 Promise<string> 형태로 받도록 설계되어 있어서, id를 Promise.resolve(id)로 감싸서 전달
-// (API 연동하면 클라이언트 컴포넌트로 분리 필요..!?)
+// (API 연동하면 클라이언트 컴포넌트로 분리 필요..!)

--- a/src/components/admin/resume/DeleteResumeButton.tsx
+++ b/src/components/admin/resume/DeleteResumeButton.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+interface Props {
+  id: string;
+}
+
+export default function DeleteResumeButton({ id }: Props) {
+  const router = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    if (!window.confirm('정말 삭제하시겠습니까?')) return;
+    try {
+      setIsDeleting(true);
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_EXTERNAL_BASE_URL}/api/admin/resume/${id}`,
+        { method: 'DELETE' },
+      );
+
+      if (!res.ok) throw new Error('삭제 실패');
+
+      alert('이력서가 삭제되었습니다.');
+      router.push('/admin/user');
+    } catch (err) {
+      console.error(err);
+      alert('삭제 실패');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleDelete}
+      disabled={isDeleting}
+      className='inline-flex w-fit items-center justify-center rounded-md bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700 disabled:opacity-50'
+    >
+      {isDeleting ? '삭제 중...' : '삭제'}
+    </button>
+  );
+}

--- a/src/components/admin/resume/ResumeModal.tsx
+++ b/src/components/admin/resume/ResumeModal.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { useResumes } from '@/hooks/useResumes';
+
+interface ResumeModalProps {
+  userId: number;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ResumeModal({ userId, open, onClose }: ResumeModalProps) {
+  const router = useRouter();
+  const { data: resumes, refetch } = useResumes(userId);
+  const didRefetch = useRef(false); // refetch 무한 호출 방지
+
+  useEffect(() => {
+    if (open && !didRefetch.current) {
+      refetch();
+      didRefetch.current = true;
+    }
+
+    // 모달 닫힐 때 다시 refetch 허용
+    if (!open) {
+      didRefetch.current = false;
+    }
+  }, [open, refetch]);
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className='max-w-md'>
+        <DialogHeader>
+          <DialogTitle>이력서 목록</DialogTitle>
+        </DialogHeader>
+
+        <div className='space-y-2'>
+          {resumes.length === 0 ? (
+            <p className='text-muted-foreground text-sm'>등록된 이력서가 없습니다.</p>
+          ) : (
+            resumes.map((resume) => (
+              <Button
+                key={resume.id}
+                variant='outline'
+                className='w-full justify-start'
+                onClick={() => {
+                  router.push(`/admin/resume/${resume.id}`);
+                  onClose();
+                }}
+              >
+                {resume.title}
+              </Button>
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/admin/user/UserTabs.tsx
+++ b/src/components/admin/user/UserTabs.tsx
@@ -5,23 +5,23 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { UserTable } from './UserTable';
 
 export function UserTabs() {
-  const [tab, setTab] = useState('personal');
+  const [tab, setTab] = useState('seeker');
 
   return (
     <div className='p-50 pt-20 pb-20'>
       <h2 className='p-2 text-xl font-bold'>전체 회원 목록</h2>
       <Tabs value={tab} onValueChange={setTab}>
         <TabsList className='grid grid-cols-2'>
-          <TabsTrigger value='personal'>개인회원</TabsTrigger>
-          <TabsTrigger value='corporate'>기업회원</TabsTrigger>
+          <TabsTrigger value='seeker'>개인회원</TabsTrigger>
+          <TabsTrigger value='business'>기업회원</TabsTrigger>
         </TabsList>
 
-        <TabsContent value='personal'>
-          <UserTable userType='personal' />
+        <TabsContent value='seeker'>
+          <UserTable userType='seeker' />
         </TabsContent>
 
-        <TabsContent value='corporate'>
-          <UserTable userType='corporate' />
+        <TabsContent value='business'>
+          <UserTable userType='business' />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/components/admin/user/UserTabs.tsx
+++ b/src/components/admin/user/UserTabs.tsx
@@ -9,21 +9,21 @@ export function UserTabs() {
 
   return (
     <div className='p-50 pt-20 pb-20'>
-        <h2 className='p-2 text-xl font-bold'>전체 회원 목록</h2>
-    <Tabs value={tab} onValueChange={setTab}>
-      <TabsList className='grid grid-cols-2'>
-        <TabsTrigger value='personal'>개인회원</TabsTrigger>
-        <TabsTrigger value='corporate'>기업회원</TabsTrigger>
-      </TabsList>
+      <h2 className='p-2 text-xl font-bold'>전체 회원 목록</h2>
+      <Tabs value={tab} onValueChange={setTab}>
+        <TabsList className='grid grid-cols-2'>
+          <TabsTrigger value='personal'>개인회원</TabsTrigger>
+          <TabsTrigger value='corporate'>기업회원</TabsTrigger>
+        </TabsList>
 
-      <TabsContent value='personal'>
-        <UserTable userType='personal' />
-      </TabsContent>
+        <TabsContent value='personal'>
+          <UserTable userType='personal' />
+        </TabsContent>
 
-      <TabsContent value='corporate'>
-        <UserTable userType='corporate' />
-      </TabsContent>
-    </Tabs>
+        <TabsContent value='corporate'>
+          <UserTable userType='corporate' />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/src/components/admin/user/columns.tsx
+++ b/src/components/admin/user/columns.tsx
@@ -5,7 +5,10 @@ import { AdminUser } from '@/types/user';
 import { Button } from '@/components/ui/button';
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 
-export const getColumns = (router: AppRouterInstance): ColumnDef<AdminUser>[] => {
+export const getColumns = (
+  router: AppRouterInstance,
+  onOpenResumeModal: (userId: number) => void,
+): ColumnDef<AdminUser>[] => {
   return [
     {
       accessorKey: 'base.id',
@@ -23,7 +26,6 @@ export const getColumns = (router: AppRouterInstance): ColumnDef<AdminUser>[] =>
           <div className='flex items-center gap-2'>
             <span>{name}</span>
             <div className='ml-6'>
-              {/* 프로필 페이지 이동 */}
               <Button
                 variant='outline'
                 size='sm'
@@ -33,12 +35,11 @@ export const getColumns = (router: AppRouterInstance): ColumnDef<AdminUser>[] =>
                 프로필
               </Button>
 
-              {/* 이력서 페이지 이동 */}
               <Button
                 variant='outline'
                 size='sm'
                 className='px-2 py-1 text-xs'
-                onClick={() => router.push(`/admin/resume/${row.original.base.id}`)}
+                onClick={() => onOpenResumeModal(row.original.base.id)}
               >
                 이력서
               </Button>

--- a/src/components/admin/user/columns.tsx
+++ b/src/components/admin/user/columns.tsx
@@ -23,6 +23,7 @@ export const getColumns = (router: AppRouterInstance): ColumnDef<AdminUser>[] =>
           <div className='flex items-center gap-2'>
             <span>{name}</span>
             <div className='ml-6'>
+              {/* 프로필 페이지 이동 */}
               <Button
                 variant='outline'
                 size='sm'
@@ -31,7 +32,14 @@ export const getColumns = (router: AppRouterInstance): ColumnDef<AdminUser>[] =>
               >
                 프로필
               </Button>
-              <Button variant='outline' size='sm' className='px-2 py-1 text-xs'>
+
+              {/* 이력서 페이지 이동 */}
+              <Button
+                variant='outline'
+                size='sm'
+                className='px-2 py-1 text-xs'
+                onClick={() => router.push(`/admin/resume/${row.original.base.id}`)}
+              >
                 이력서
               </Button>
             </div>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -2,11 +2,11 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { Button } from '../ui/button';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useAuthStore } from '@/store/useAuthStore';
 import { logoutUser } from '@/api/user';
-import { useRouter } from 'next/navigation';
 
 const userNavItems = [
   { name: '공공 공고', href: '/public-jobs' },
@@ -15,7 +15,7 @@ const userNavItems = [
   { name: 'ADMIN', href: '/admin' }, // 임시
 ];
 
-//관리자용
+// 관리자용
 const adminNavItems = [
   { name: '회원 관리', href: '/admin/user' },
   { name: '공고 관리', href: '/admin/jobs' },
@@ -28,6 +28,13 @@ export default function Header() {
   const { accessToken, logout } = useAuthStore();
   const router = useRouter();
 
+  // hydration mismatch 방지를 위한 mounted 상태
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   const handleLogout = async () => {
     try {
       await logoutUser();
@@ -39,7 +46,6 @@ export default function Header() {
     }
   };
 
-  //경로가 /admin 시작일때 관리자메뉴
   const isAdminPage = pathname.startsWith('/admin');
   const navItems = isAdminPage ? adminNavItems : userNavItems;
 
@@ -57,6 +63,7 @@ export default function Header() {
           />
         </Link>
       </h1>
+
       <nav className='grow px-12'>
         <ul className='flex items-center gap-4'>
           {navItems.map((item) => (
@@ -73,8 +80,8 @@ export default function Header() {
       </nav>
 
       <div className='flex items-center gap-2'>
-        {/* 유저 정보 받으면 원 안에 프사 넣은걸로 바꾸기 */}
-        {accessToken ? (
+        {/* 수정: 클라이언트 마운트 후에만 accessToken으로 분기 */}
+        {!mounted ? null : accessToken ? (
           <>
             <Link href='/dashboard/profile'>
               <Button className='bg-main-light hover:bg-main-dark cursor-pointer text-white'>
@@ -112,6 +119,3 @@ export default function Header() {
     </header>
   );
 }
-
-// 유저가 관리자일 경우 nav 조건부 렌더링
-// 로그인 상태에 따라 버튼 조건부 렌더링

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <main className='flex h-full w-full flex-col overflow-y-auto'>
+      <div className='flex w-full flex-1'>
+        <div className='mx-auto flex w-full max-w-[1200px] gap-4 py-6'>
+          <div className='flex flex-1 flex-col gap-4'>{children}</div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/hooks/useResumes.ts
+++ b/src/hooks/useResumes.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useState } from 'react';
+
+// 목업용 타입
+export interface Resume {
+  id: number;
+  title: string;
+  user_id: number;
+}
+
+export function useResumes(userId: number) {
+  const [data, setData] = useState<Resume[]>([]);
+
+  const refetch = () => {
+    // 실제로는 API 요청으로 대체해야 함
+    setData([
+      { id: 1, title: '첫 번째 이력서', user_id: userId },
+      { id: 2, title: '두 번째 이력서', user_id: userId },
+    ]);
+  };
+
+  return { data, refetch };
+}

--- a/src/types/resume.ts
+++ b/src/types/resume.ts
@@ -1,0 +1,26 @@
+export interface ResumeResponse {
+  id: number;
+  user: {
+    id: number;
+  };
+  title: string;
+  visibility: boolean;
+  name: string;
+  phone_number: string;
+  email: string;
+  image_profile: string;
+  interests: string;
+  desired_area: string;
+  education: string;
+  school_name: string;
+  graduation_status: string;
+  introduce: string;
+  status: string;
+  document_url: string;
+  work_experiences: {
+    id: number;
+    company: string;
+    period: string;
+    position: string;
+  }[];
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #95 

## 📝 작업 내용

> 관리자용 회원관리 페이지에서 개인회원 이력서 버튼 클릭시 이력서 컴포넌트로(현재 목데이터) 연결하고, 삭제 버튼 추가했습니다.
서버 응답값에 맞춰 로직을 정리했습니다.
후에 이력서 api 연동되면 컴포넌트 다시 정리하려고 합니다.

### 스크린샷 (선택)
![스크린샷 2025-05-02 오후 8 54 25](https://github.com/user-attachments/assets/69e02d46-b73b-4e65-bf80-81cd16dd5ca3)
![스크린샷 2025-05-02 오후 8 54 35](https://github.com/user-attachments/assets/b70ebf4c-4fa9-4aca-b2fa-24634c358be1)
![스크린샷 2025-05-02 오후 8 55 01](https://github.com/user-attachments/assets/87071578-e50a-4539-aebe-787e79d6ed3c)


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
