### PR TITLE
✨ 공공 일자리 API 구현 (공공데이터 포털)

### DIFF
--- a/src/app/(auth)/dashboard/job-seeker/profile/page.tsx
+++ b/src/app/(auth)/dashboard/job-seeker/profile/page.tsx
@@ -1,4 +1,5 @@
 // import fetchOnServer from '@/api/serverFetcher';
+
 import SeekerProfile from '@/components/profile/SeekerProfile';
 import Link from 'next/link';
 

--- a/src/app/(main)/public-jobs/page.tsx
+++ b/src/app/(main)/public-jobs/page.tsx
@@ -39,3 +39,13 @@ export default function PublicJobsPage() {
     </div>
   );
 }
+
+// TODO: 공공 일자리 API 연결하기
+// offset, limit을 사용해서 페이지네이션 구현했어요. 밑에는 예시 코드 이거 조정해서 쓰시면 될것 같아요! (기태)
+// 서버 컴포넌트에서는 잘 작동하는걸 확인했어요. 클라이언트 컴포넌트에서 사용할수 있게 수정해서 사용하세요! (SWR)
+//
+// import { PublicJobsResponse } from '@/types/publicJob';
+//
+// const response = await fetch('http://localhost:3000/api/public-jobs?offset=20&limit=20');
+// const publicJobs: PublicJobsResponse = await response.json();
+// console.log('publicJobs: ', publicJobs);

--- a/src/app/api/public-jobs/route.ts
+++ b/src/app/api/public-jobs/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PublicJobPosting, PublicJobPostingResponse } from '@/types/publicJob';
+
+interface ApiError extends Error {
+  status?: number;
+}
+
+const OPTIONS = ['시니어', '실버', '노인', '중장년'] as const;
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const offsetParam = searchParams.get('offset');
+  const limitParam = searchParams.get('limit');
+
+  const offset = offsetParam ? parseInt(offsetParam, 10) : 0;
+  const limit = limitParam ? parseInt(limitParam, 10) : 10;
+
+  // 유효성 검사
+  if (isNaN(offset) || offset < 0) {
+    return NextResponse.json({ error: '유효하지 않은 offset 값입니다. (0 이상)' }, { status: 400 });
+  }
+  if (isNaN(limit) || limit <= 0 || limit > 30) {
+    // 페이지당 최대 30개 까지만
+    return NextResponse.json({ error: '유효하지 않은 limit 값입니다. (1 ~ 30)' }, { status: 400 });
+  }
+
+  try {
+    const publicJobsPackages = await Promise.all(
+      OPTIONS.map(async (option) => {
+        const params = new URLSearchParams({
+          serviceKey:
+            'wegLdJbuHNke8Bf+CCJQxf1x9B6yBofoEc9wFxjGxT+NcGEg1F/JgmGCQbWrVwHBneeGzdYVutBWxRcZx5jaAg==',
+          numOfRows: '100',
+          recrutPbancTtl: option,
+        });
+
+        const response = await fetch(`https://apis.data.go.kr/1051000/recruitment/list?${params}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          const errorMessage =
+            errorData.message ||
+            `공공 데이터 포탈 API 호출 실패: ${response.status} ${response.statusText}`;
+          console.error(`공공 데이터 포탈 API 호출 오류 (${response.status}):`, errorData);
+
+          const error: ApiError = new Error(`공공 데이터 포탈 API 호출 오류: ${errorMessage}`);
+          error.status = response.status;
+          throw error;
+        }
+
+        return response.json();
+      }),
+    );
+
+    // 모든 result 배열을 합치기
+    const mergedResults: PublicJobPostingResponse[] = publicJobsPackages.flatMap(
+      (pkg) => pkg.result ?? [],
+    );
+
+    const publicJobs: PublicJobPosting[] = mergedResults.map((result) => ({
+      title: result.recrutPbancTtl,
+      company: result.instNm,
+      job: result.ncsCdNmLst,
+      position: result.recrutSeNm,
+      employmentType: result.hireTypeNmLst,
+      location: result.workRgnNmLst,
+      qualification: result.aplyQlfcCn,
+      disqualification: result.disqlfcRsn,
+      education: result.acbgCondNmLst,
+      preference: result.prefCondCn,
+      preferenceDetail: result.prefCn,
+      hiringProcess: result.scrnprcdrMthdExpln,
+      postedAt: result.pbancBgngYmd,
+      deadline: result.pbancEndYmd,
+      url: result.srcUrl,
+    }));
+
+    const paginatedPublicJobs = publicJobs.slice(offset, offset + limit);
+    const totalItems = publicJobs.length;
+
+    return NextResponse.json(
+      {
+        total: totalItems,
+        offset,
+        limit,
+        data: paginatedPublicJobs,
+      },
+      { status: 200 },
+    );
+
+    // 에러
+  } catch (error) {
+    console.error('API 라우트 핸들러 오류:', error);
+
+    if (error instanceof Error) {
+      const apiError = error as ApiError;
+      if (typeof apiError.status === 'number' && typeof apiError.message === 'string') {
+        return NextResponse.json({ error: apiError.message }, { status: apiError.status });
+      }
+    }
+
+    // TypeError: Failed to fetch 와 같은 네트워크 관련 에러 처리
+    if (error instanceof TypeError && error.message === 'Failed to fetch') {
+      return NextResponse.json({ error: '네트워크 연결 요청 실패' }, { status: 503 });
+    }
+
+    return NextResponse.json({ error: '내부 서버 오류' }, { status: 500 });
+  }
+}

--- a/src/types/publicJob.ts
+++ b/src/types/publicJob.ts
@@ -1,0 +1,59 @@
+// 공공 데이터 포탈 API 응답 타입
+export type PublicJobPostingResponse = {
+  recrutPblntSn: number | null;
+  pblntInstCd: string | null;
+  pbadmsStdInstCd: string | null;
+  instNm: string | null;
+  ncsCdLst: string | null;
+  ncsCdNmLst: string | null;
+  hireTypeLst: string | null;
+  hireTypeNmLst: string | null;
+  workRgnLst: string | null;
+  workRgnNmLst: string | null;
+  recrutSe: string | null;
+  recrutSeNm: string | null;
+  prefCondCn: string | null;
+  recrutNope: number | null;
+  pbancBgngYmd: string | null;
+  pbancEndYmd: string | null;
+  recrutPbancTtl: string | null;
+  srcUrl: string | null;
+  replmprYn: string | null;
+  aplyQlfcCn: string | null;
+  disqlfcRsn: string | null;
+  scrnprcdrMthdExpln: string | null;
+  prefCn: string | null;
+  acbgCondLst: string | null;
+  acbgCondNmLst: string | null;
+  nonatchRsn: string | null;
+  ongoingYn: string | null;
+  decimalDay: number | null;
+  files: string[] | null;
+  steps: string[] | null;
+};
+
+// 데이터 타입 정제
+export type PublicJobPosting = {
+  title: string | null; // recrutPbancTtl
+  company: string | null; // instNm
+  job: string | null; // ncsCdNmLst
+  position: string | null; // recrutSeNm
+  employmentType: string | null; // hireTypeNmLst
+  location: string | null; // workRgnNmLst
+  qualification: string | null; // aplyQlfcCn
+  disqualification: string | null; // disqlfcRsn
+  education: string | null; // acbgCondNmLst
+  preference: string | null; // prefCondCn
+  preferenceDetail: string | null; // prefCn
+  hiringProcess: string | null; // scrnprcdrMthdExpln
+  postedAt: string | null; // pbancBgngYmd
+  deadline: string | null; // pbancEndYmd
+  url: string | null; // srcUrl
+};
+
+export type PublicJobsResponse = {
+  total: number;
+  offset: number;
+  limit: number;
+  data: PublicJobPosting[];
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #175 

## 📝 작업 내용

> 시니어용 공공 일자리 데이터 긁어오기 (공공데이터 포털)
> API 제작
> http://localhost:3000/api/public-jobs

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/8f24ae88-91be-4b3b-9bf4-cdde8069f2a4)


## 💬 리뷰 요구사항 (선택)

> 출처
> https://www.data.go.kr/data/15125273/openapi.do#/API%20%EB%AA%A9%EB%A1%9D/list
> 
> 2팀꺼랑 같은 데이터 긁어왔어요. 검색 조건을 여러개 설정해서 동시에 페칭해와서 합친거라 갯수는 좀 더 많을지도?
> 받아오는 데이터 형식이 토나온다 하셔서, 쓸만한거 위주로 추려서 구조 바꿔놨어요.
> 
