### PR TITLE
✨ 관리자 공고관리 페이지 상세 구현

### DIFF
--- a/src/app/admin/jobs/[id]/page.tsx
+++ b/src/app/admin/jobs/[id]/page.tsx
@@ -1,0 +1,26 @@
+import JobPostingAdmin from '@/components/admin/jobs/JobPostingAdmin';
+import AdminLayout from '@/components/layout/AdminLayout';
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+    const { id } = await params;
+    console.log(id);
+
+  try {
+    if (!id) throw new Error('공고 ID가 유효하지 않습니다.');
+
+    return (
+      <AdminLayout>
+        <JobPostingAdmin id={id} />
+      </AdminLayout>
+    );
+  } catch (error) {
+    return (
+      <AdminLayout>
+        <div className='p-10 text-center text-red-600'>
+          <h2 className='mb-2 text-xl font-bold'>공고를 불러오는 데 실패했습니다.</h2>
+          <p className='text-sm'>{(error as Error).message}</p>
+        </div>
+      </AdminLayout>
+    );
+  }
+}

--- a/src/app/admin/jobs/page.tsx
+++ b/src/app/admin/jobs/page.tsx
@@ -1,5 +1,10 @@
 import JobPostingAdminClient from '@/components/admin/jobs/JobPostingAdminClient';
+import AdminLayout from '@/components/layout/AdminLayout';
 
-export default async function AdminJobPostingPage() {
-  return <JobPostingAdminClient />;
+export default function AdminJobListPage() {
+  return (
+    <AdminLayout>
+      <JobPostingAdminClient />
+    </AdminLayout>
+  );
 }

--- a/src/components/admin/jobs/JobPostingActionPanel.tsx
+++ b/src/components/admin/jobs/JobPostingActionPanel.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { fetchOnClient } from '@/api/clientFetcher';
+
+interface Props {
+  id: string;
+  status: string;
+}
+
+export default function JobPostingActionPanel({ id, status }: Props) {
+  const router = useRouter();
+  const [rejectReason, setRejectReason] = useState('');
+  const [rejectOpen, setRejectOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [rejectLoading, setRejectLoading] = useState(false);
+
+  const approve = async () => {
+    setLoading(true);
+    try {
+      await fetchOnClient(`/api/admin/job-posting/${id}/`, {
+        method: 'PATCH',
+        body: JSON.stringify({ status: '모집중' }),
+      });
+      router.push('/admin/jobs');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const reject = async () => {
+    if (!rejectReason.trim()) return alert('반려 사유를 입력해주세요.');
+    setRejectLoading(true);
+    try {
+      await fetchOnClient(`/api/admin/job-posting/${id}/reject-posting/`, {
+        method: 'POST',
+        body: JSON.stringify({ content: rejectReason }),
+      });
+      await fetchOnClient(`/api/admin/job-posting/${id}/`, {
+        method: 'PATCH',
+        body: JSON.stringify({ status: '반려됨' }),
+      });
+      setRejectOpen(false);
+      router.push('/admin/jobs');
+    } finally {
+      setRejectLoading(false);
+    }
+  };
+
+  if (status !== '대기중') return null;
+
+  return (
+    <div className='mb-4 flex justify-end gap-2'>
+      <Button onClick={approve} disabled={loading}>
+        {loading ? '승인 중...' : '승인하기'}
+      </Button>
+      <Dialog open={rejectOpen} onOpenChange={setRejectOpen}>
+        <DialogTrigger asChild>
+          <Button variant='destructive'>반려하기</Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>반려 사유 입력</DialogTitle>
+          </DialogHeader>
+          <Textarea
+            value={rejectReason}
+            onChange={(e) => setRejectReason(e.target.value)}
+            placeholder='반려 사유를 입력해주세요 (1~1000자)'
+            rows={6}
+          />
+          <DialogFooter>
+            <Button onClick={reject} disabled={rejectLoading} variant='destructive'>
+              {rejectLoading ? '처리 중...' : '반려하기'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/admin/jobs/JobPostingAdmin.tsx
+++ b/src/components/admin/jobs/JobPostingAdmin.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import {
+  BookCheck,
+  Briefcase,
+  Calendar,
+  CircleDollarSign,
+  Clock,
+  FileStack,
+  FolderOpen,
+  GraduationCap,
+  Info,
+  MapPin,
+  PencilLine,
+  UsersRound,
+} from 'lucide-react';
+import JobPostingViewer from '@/components/common/text-editor/JobPostingViewer';
+import useJobPosting from '@/hooks/useJobPosting';
+import JobPostingActionPanel from './JobPostingActionPanel';
+
+interface Props {
+  id: string;
+}
+
+export default function JobPostingAdmin({ id }: Props) {
+  const { jobPosting, loading, error } = useJobPosting(id);
+
+  if (error) return null;
+  if (loading || !jobPosting) return <p className='text-gray-400'>로딩 중...</p>;
+
+  return (
+    <article className='flex flex-col gap-4'>
+      {/* 승인/반려 */}
+      <JobPostingActionPanel id={id} status={jobPosting.status} />
+
+      {/* 공고 제목 */}
+      <div className='flex items-center justify-between border-b pb-4'>
+        <h2 className='text-2xl font-bold'>{jobPosting.title}</h2>
+        <span className='rounded-lg bg-zinc-100 px-3 py-1 text-zinc-800'>
+          {jobPosting.employment_type}
+        </span>
+      </div>
+
+      {/* 회사 및 기본정보 */}
+      <div className='flex items-center justify-between rounded-md border px-8 py-6'>
+        <div className='flex flex-col gap-4'>
+          <span className='text-xl font-bold text-zinc-800'>{jobPosting.company}</span>
+          <div className='flex gap-2'>
+            <span className='rounded-lg bg-zinc-100 px-3 py-1 text-zinc-800'>
+              {jobPosting.status}
+            </span>
+            <span className='rounded-lg bg-zinc-100 px-3 py-1 text-zinc-800'>
+              조회: {jobPosting.view_count}
+            </span>
+            <span className='rounded-lg bg-zinc-100 px-3 py-1 text-zinc-800'>
+              신고: {jobPosting.report}
+            </span>
+          </div>
+        </div>
+        <div className='flex flex-col gap-5'>
+          {/* <span className='text-zinc-800'>
+            작성일:{' '}
+            {jobPosting.created_at && isValid(parseISO(jobPosting.created_at))
+              ? format(parseISO(jobPosting.created_at), 'yyyy-MM-dd')
+              : '날짜 없음'}
+          </span>
+
+          <span className='text-zinc-800'>
+            수정일:{' '}
+            {isValid(parseISO(jobPosting.updated_at))
+              ? format(parseISO(jobPosting.updated_at), 'yyyy-MM-dd')
+              : '날짜 없음'}
+          </span> */}
+        </div>
+      </div>
+
+      {/* 모집 조건 */}
+      <div className='flex flex-col gap-6 rounded-md border p-4 sm:p-8 md:p-12'>
+        <h3 className='text-main-light text-lg font-extrabold'>모집 조건</h3>
+        <div className='flex flex-col gap-4 lg:flex-row'>
+          <div className='flex flex-col gap-4 lg:w-1/2'>
+            <div className='flex items-center gap-4'>
+              <Briefcase className='size-4' />
+              <span>모집 직무: {jobPosting.position}</span>
+            </div>
+            <div className='flex items-center gap-4'>
+              <FolderOpen className='size-4' />
+              <span>근무 형태: {jobPosting.employ_method}</span>
+            </div>
+            <div className='flex items-center gap-4'>
+              <Calendar className='size-4' />
+              <span>마감일: {jobPosting.deadline}</span>
+            </div>
+            <div className='flex items-center gap-4'>
+              <UsersRound className='size-4' />
+              <span>모집 인원: {jobPosting.recruitment_count}명</span>
+            </div>
+          </div>
+
+          <div className='flex flex-col gap-4 lg:w-1/2'>
+            <div className='flex items-center gap-4'>
+              <BookCheck className='size-4' />
+              <span>자격 요건: {jobPosting.career}</span>
+            </div>
+            <div className='flex items-center gap-4'>
+              <GraduationCap className='size-4' />
+              <span>학력 요건: {jobPosting.education}</span>
+            </div>
+            <div className='flex items-center gap-4'>
+              <CircleDollarSign className='size-4' />
+              <span>급여: {jobPosting.salary}</span>
+            </div>
+            <div className='flex items-center gap-4'>
+              <Clock className='size-4' />
+              <span>근무 시간: {jobPosting.work_time}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 회사 약력 */}
+      <div className='rounded-md border p-4 sm:p-8 md:p-12'>
+        <h3 className='text-main-light flex items-center gap-4 text-lg font-bold'>
+          <FileStack className='size-4' /> 회사 약력
+        </h3>
+        <pre className='whitespace-pre-wrap text-zinc-800'>{jobPosting.history}</pre>
+      </div>
+
+      {/* 주요 업무 */}
+      <div className='rounded-md border p-4 sm:p-8 md:p-12'>
+        <h3 className='text-main-light flex items-center gap-4 text-lg font-bold'>
+          <Info className='size-4' /> 주요 업무
+        </h3>
+        <pre className='whitespace-pre-wrap text-zinc-800'>{jobPosting.summary}</pre>
+      </div>
+
+      {/* 근무지 정보 */}
+      <div className='rounded-md border p-4 sm:p-8 md:p-12'>
+        <h3 className='text-main-light flex items-center gap-4 text-lg font-bold'>
+          <MapPin className='size-4' /> 근무지 정보
+        </h3>
+        <div className='flex h-60 items-center justify-center rounded-md border'>지도</div>
+        <p className='text-zinc-800'>{jobPosting.location}</p>
+      </div>
+
+      {/* 상세 모집 내용 */}
+      <div className='rounded-md border p-4 sm:p-8 md:p-12'>
+        <h3 className='text-main-light flex items-center gap-4 text-lg font-bold'>
+          <PencilLine className='size-4' /> 상세 모집 내용
+        </h3>
+        <JobPostingViewer content={jobPosting.description} />
+      </div>
+    </article>
+  );
+}

--- a/src/components/admin/jobs/JobPostingAdminClient.tsx
+++ b/src/components/admin/jobs/JobPostingAdminClient.tsx
@@ -3,23 +3,21 @@
 import { useState } from 'react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import JobPostingTable from './JobPostingTable';
-import { JobPosting } from './columns';
-import useSWR from 'swr';
-import { fetchOnClient } from '@/api/clientFetcher';
+import useJobPostingList from '@/hooks/useJobPostingList';
 
 export default function JobPostingAdminClient() {
   const [tab, setTab] = useState<'approved' | 'unapproved'>('approved');
+  const { postings } = useJobPostingList();
 
-  // 전체 공고 데이터 요청
-  const { data = [] } = useSWR<JobPosting[]>('/api/admin/job-posting/', fetchOnClient);
+  const approvedStatuses = ['모집중', '마감 임박', '모집 종료', '블라인드'];
+  const approvedPostings = postings.filter((item) =>
+    approvedStatuses.includes(item.status),
+  );
 
-  // 승인 공고: status가 아래 중 하나일 때
-  const approvedStatuses = ['모집중', '"마감 임박', '모집 종료', '블라인드'];
-  const approvedPostings = data.filter((item) => approvedStatuses.includes(item.status));
-
-  // 미승인 공고: Pending or Rejected
   const unapprovedStatuses = ['대기중', '반려됨'];
-  const unapprovedPostings = data.filter((item) => unapprovedStatuses.includes(item.status));
+  const unapprovedPostings = postings.filter((item) =>
+    unapprovedStatuses.includes(item.status),
+  );
 
   return (
     <div className='p-50 pt-20 pb-20'>

--- a/src/components/admin/jobs/JobPostingTable.tsx
+++ b/src/components/admin/jobs/JobPostingTable.tsx
@@ -1,12 +1,15 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import DataTable from '../table/DataTable';
-import { JobPosting, columns } from './columns';
+import { JobPosting, getColumns } from './columns';
 
 interface Props {
   data: JobPosting[];
 }
 
 export default function JobPostingTable({ data }: Props) {
-  return <DataTable columns={columns} data={data} />;
+  const router = useRouter();
+
+  return <DataTable columns={getColumns(router)} data={data} />;
 }

--- a/src/components/admin/jobs/columns.tsx
+++ b/src/components/admin/jobs/columns.tsx
@@ -1,12 +1,21 @@
 import { JobPostingWithRejects } from '@/types/Schema/jobPostingSchema';
 import { ColumnDef } from '@tanstack/react-table';
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 
 export type JobPosting = JobPostingWithRejects;
 
-export const columns: ColumnDef<JobPosting>[] = [
+export const getColumns = (router: AppRouterInstance): ColumnDef<JobPosting>[] => [
   {
     accessorKey: 'title',
     header: '공고 제목',
+    cell: ({ row }) => (
+      <button
+        className='text-blue-600 underline hover:opacity-70'
+        onClick={() => router.push(`/admin/jobs/${row.original.id}`)}
+      >
+        {row.original.title}
+      </button>
+    ),
   },
   {
     accessorKey: 'company',

--- a/src/hooks/useJobPosting.ts
+++ b/src/hooks/useJobPosting.ts
@@ -1,0 +1,18 @@
+import useSWR from 'swr';
+import { fetchOnClient } from '@/api/clientFetcher';
+import { JobPostingWithRejects } from '@/types/Schema/jobPostingSchema';
+
+export default function useJobPosting(id: string) {
+  const { data, error, isLoading, mutate } = useSWR<JobPostingWithRejects>(
+    `/api/admin/job-posting/${id}/`,
+    fetchOnClient,
+  );
+
+  return {
+    jobPosting: data,
+    error,
+    loading: isLoading,
+    mutate,
+  };
+}
+//상세 내용 불러오는 훅

--- a/src/hooks/useJobPostingList.ts
+++ b/src/hooks/useJobPostingList.ts
@@ -1,0 +1,18 @@
+import useSWR from 'swr';
+import { fetchOnClient } from '@/api/clientFetcher';
+import { JobPostingWithRejects } from '@/types/Schema/jobPostingSchema';
+
+export default function useJobPostingList() {
+  const { data, error, isLoading, mutate } = useSWR<JobPostingWithRejects[]>(
+    '/api/admin/job-posting/',
+    fetchOnClient,
+  );
+
+  return {
+    postings: data ?? [],
+    error,
+    loading: isLoading,
+    mutate,
+  };
+}
+//전체 리스트 불러오는 훅


### PR DESCRIPTION
관리자 공고관리 페이지 상세 구현

## #️⃣ 연관된 이슈

> ex) #162 

## 📝 작업 내용

> 관리자 공고관리 페이지에서 승인, 미승인 공고에 따라서 탭 나누고, 미승인 공고에서 승인, 반려처리 할 수 있는 버튼 만들었습니다. 
반려하기 클릭시 사유 입력할 수 있는 모달창 나오고, 안에 사유 입력하고 저장하면 반려되으로 상태 변경됩니다
table 크기가 다른 관리 페이지랑 다른점, 버튼 색 다른점은 전체적으로 UI 손볼때 손보려고 합니다..

### 스크린샷 (선택)
![스크린샷 2025-05-08 오후 4 21 47](https://github.com/user-attachments/assets/cc21334c-4475-486e-91c0-aa91752025d8)
![스크린샷 2025-05-08 오후 4 24 11](https://github.com/user-attachments/assets/821b63fb-0f21-4ee8-82b1-6c776114ba2f)
![스크린샷 2025-05-08 오후 4 24 39](https://github.com/user-attachments/assets/5d63b517-ee4a-402d-8265-bae6a72bd947)

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
